### PR TITLE
trigger does not default to "default" broker on v1

### DIFF
--- a/specs/eventing/broker.md
+++ b/specs/eventing/broker.md
@@ -37,8 +37,7 @@ While a Trigger is Ready, it SHOULD indicate its subscriber's URI via the
 `status.subscriberUri` field.
 
 Triggers MUST be assigned to exactly one Broker. The assigned Broker of a
-trigger SHOULD be immutable. Triggers SHOULD be assigned a default Broker upon
-creation if no Broker is specified by the user.
+trigger SHOULD be immutable.
 
 A Trigger MAY be created before its assigned Broker exists. A Trigger SHOULD
 progress to Ready when its assigned Broker exists and is Ready.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Fixes: https://github.com/knative/eventing/issues/5081

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- In v1 we do not default the Broker for a Trigger. Update the spec.
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
