### PR TITLE
drop usage of versions, remove status.addressable

### DIFF
--- a/specs/eventing/channel.md
+++ b/specs/eventing/channel.md
@@ -114,7 +114,7 @@ Each channel MUST have the `duck.knative.dev/addressable: "true"` label on its
 For each channel implementation a `CustomResourceDefinition` is created, like:
 
 ```
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
  name: inmemorychannels.messaging.knative.dev
@@ -124,7 +124,11 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
-  version: v1
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      ...
   names:
     kind: InMemoryChannel
     plural: inmemorychannels
@@ -155,33 +159,17 @@ currently have these versions:
 1. [v1beta1](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1beta1/channelable_types.go)
 1. [v1](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1/channelable_types.go)
 
-So, for example to indicate that the Channel supports v1beta1 duck type, you
+So, for example to indicate that the Channel supports v1 channelable duck type, you
 should annotate it like so (only showing the annotations):
 
 ```
-- apiVersion: messaging.knative.dev/v1beta1
+- apiVersion: messaging.knative.dev/v1
   kind: YourChannelType
   metadata:
-    annotations: messaging.knative.dev/subscribable: v1beta1
+    annotations: messaging.knative.dev/subscribable: v1
 ```
 
-Unfortunately, we had to make breaking changes between v1alpha1 and v1beta1
-versions, and to ensure functionality, the channel implementer must indicate
-which version they support. To ensure backwards compatibility with old channels,
-if no annotation is given, we assume it's `v1alpha1`.
-
 #### Spec Requirements
-
-##### v1beta1 Spec
-
-Each channel CRD MUST contain an array of subscribers:
-[`spec.subscribers`](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1beta1/subscribable_types.go)
-
-Note: The array of subscribers MUST NOT be set directly on the generic Channel
-custom object, but rather appended to the backing channel by the subscription
-itself.
-
-##### v1 Spec
 
 Each channel CRD MUST contain an array of subscribers:
 [`spec.subscribers`](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1/subscribable_types.go)
@@ -202,23 +190,6 @@ that particular Subscription.
 
 #### Status Requirements
 
-##### v1beta1 Status
-
-Each channel CRD MUST have a `status` subresource which contains
-
-- [`address`](https://github.com/knative/pkg/blob/main/apis/duck/v1/addressable_types.go)
-- [`subscribers`](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1beta1/subscribable_types.go)
-  (as an array)
-
-Each channel CRD SHOULD have the following fields in `Status`
-
-- [`observedGeneration`](https://github.com/knative/pkg/blob/main/apis/duck/v1/status_types.go)
-  MUST be populated if present
-- [`conditions`](https://github.com/knative/pkg/blob/main/apis/duck/v1/status_types.go)
-  (as an array) SHOULD indicate status transitions and error reasons if present
-
-##### v1 Status
-
 Each channel CRD MUST have a `status` subresource which contains
 
 - [`address`](https://github.com/knative/pkg/blob/main/apis/duck/v1/addressable_types.go)
@@ -234,25 +205,10 @@ Each channel CRD SHOULD have the following fields in `Status`
 
 #### Channel Status
 
-##### v1beta1
-
 When the channel instance is ready to receive events `status.address.url` MUST
-be populated and `status.addressable` MUST be set to `True`.
-
-##### v1
-
-When the channel instance is ready to receive events `status.address.url` MUST
-be populated and `status.addressable` MUST be set to `True`.
+be populated.
 
 #### Channel Subscriber Status
-
-##### v1beta1
-
-Each subscription to a channel is added to the channel `status.subscribers`
-automatically. The `ready` field of the subscriber identified by its `uid` MUST
-be set to `True` when the subscription is ready to be processed.
-
-##### v1
 
 Each subscription to a channel is added to the channel `status.subscribers`
 automatically. The `ready` field of the subscriber identified by its `uid` MUST

--- a/specs/eventing/channel.md
+++ b/specs/eventing/channel.md
@@ -159,8 +159,8 @@ currently have these versions:
 1. [v1beta1](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1beta1/channelable_types.go)
 1. [v1](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1/channelable_types.go)
 
-So, for example to indicate that the Channel supports v1 channelable duck type, you
-should annotate it like so (only showing the annotations):
+So, for example to indicate that the Channel supports v1 channelable duck type,
+you should annotate it like so (only showing the annotations):
 
 ```
 - apiVersion: messaging.knative.dev/v1

--- a/specs/eventing/channel.md
+++ b/specs/eventing/channel.md
@@ -156,7 +156,6 @@ Each instantiated Channel (ie, Custom Object) SHOULD have an annotation
 indicating which version of the `Channelable` duck type it conforms to. We
 currently have these versions:
 
-1. [v1beta1](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1beta1/channelable_types.go)
 1. [v1](https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1/channelable_types.go)
 
 So, for example to indicate that the Channel supports v1 channelable duck type,
@@ -284,8 +283,8 @@ _Structured Content Mode_ of the HTTP Protocol Binding for CloudEvents, although
 dispatching events using _Binary Content Mode_ is RECOMMENDED.
 
 Channels MUST send events to all subscribers which are marked with a status of
-`ready: "True"` in the channel's `status.subscribers` (v1beta1 / v1). The events
-must be sent to the `subscriberURI` field of `spec.subscribers` (v1beta1 / v1).
+`ready: "True"` in the channel's `status.subscribers` (v1). The events
+must be sent to the `subscriberURI` field of `spec.subscribers` (v1).
 Each channel implementation will have its own quality of service guarantees
 (e.g. at least once, at most once, etc) which SHOULD be documented.
 
@@ -333,6 +332,7 @@ following attributes:
 
 ## Changelog
 
+- `0.22.x release`: Drop mention of `v1beta1` `channelable` duck type.
 - `0.11.x release`: CloudEvents in 0.3 and 1.0 are supported.
 - `0.13.x release`: Types in the API group `messaging.knative.dev` will be
   promoted from `v1alpha1`to `v1beta1`. Add requirement for labeling Custom


### PR DESCRIPTION
- `channel.status.addressable` has never been a thing we have supported, delete this.
- channels at v1beta1 are the same as v1, I think we can talk about each as the same thing, we don't care so much about v1beta1 channels, as they should move all to v1. No new channel should pick the v1beta1 shape, just use the v1 shape. They are the same.
- upgrades the CRD example to v1