### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 approvers:
   - knative-trademark-committee
   - technical-oversight-committee
-  - conformance-leads
+  - conformance-writers
 
 # Reviewers are suggested from the reviewers list first, then the approvers
 # list. To add reviewers while spreading the load among existing approvers,
 # copy the approvers to the reviewers list too.
 reviewers:
-- conformance-leads
+- conformance-writers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,5 +8,5 @@ aliases:
     - grantr
     - markusthoemmes
     - rhuss
-  conformance-leads:
+  conformance-writers:
     - tayarani


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
