### PR TITLE
docs: add consumer response codes to broker spec

### DIFF
--- a/specs/eventing/broker.md
+++ b/specs/eventing/broker.md
@@ -145,17 +145,15 @@ The subscriber MAY receive a confirmation that a reply event was accepted by the
 Broker. If the reply event was not accepted, the initial event SHOULD be
 redelivered to the subscriber.
 
-Subscribers SHOULD respond to event delivery with one of the following HTTP
-response codes.
+Subscribers SHOULD acknowledge delivery of an event with an HTTP 2xx response code.
 
-    * 204: Acknowlegement of receipt without event in the response.
+Subscribers MAY respond to event delivery with one of the following responses
+to provide additional contextual meaning.
+
     * 200: Acknowlegement of receipt with an event in the response.
-
-Additional valid response codes from event subscribers indicating successful
-delivery are:
-
     * 201: Acknowledgement of receipt with an event in the response indicating that a resource was created. A description of that resource SHOULD be included in the subscriber's response as an event of the corresponding type. For example, a GitHub issue was created, and an event whose type is com.github.issue is included in the response.
     * 202: Acknowledgement of receipt. Event subscribers SHOULD respond 202 to indicate an acknowledgement of receipt when the consumer simply forwards or stores the message without actually processing it. 
+    * 204: Acknowlegement of receipt without an event in the response.
 
 All other HTTP response codes SHOULD be treated as if the event delivery had failed.
 

--- a/specs/eventing/broker.md
+++ b/specs/eventing/broker.md
@@ -145,6 +145,20 @@ The subscriber MAY receive a confirmation that a reply event was accepted by the
 Broker. If the reply event was not accepted, the initial event SHOULD be
 redelivered to the subscriber.
 
+Subscribers SHOULD respond to event delivery with one of the following HTTP
+response codes.
+
+    * 204: Acknowlegement of receipt without event in the response.
+    * 200: Acknowlegement of receipt with an event in the response.
+
+Additional valid response codes from event subscribers indicating successful
+delivery are:
+
+    * 201: Acknowledgement of receipt with an event in the response indicating that a resource was created. A description of that resource SHOULD be included in the subscriber's response as an event of the corresponding type. For example, a GitHub issue was created, and an event whose type is com.github.issue is included in the response.
+    * 202: Acknowledgement of receipt. Event subscribers SHOULD respond 202 to indicate an acknowledgement of receipt when the consumer simply forwards or stores the message without actually processing it. 
+
+All other HTTP response codes SHOULD be treated as if the event delivery had failed.
+
 ### Observability
 
 The Broker SHOULD expose a variety of metrics, including, but not limited to:


### PR DESCRIPTION


Signed-off-by: Lance Ball <lball@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

- spec: add guidance for event consumers/subscribers regarding the semantic meaning of HTTP response codes on event delivery

/kind documentation

Fixes: https://github.com/knative/eventing/issues/4125

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Additional guidance for event subscribers is provided, indicating accepted HTTP response codes for successful delivery, and the semantic meaning of each code.
```

