### PR TITLE
Allow max #containers to be larger than 1

### DIFF
--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -27,7 +27,7 @@ APPROVED</p>
 
    </td>
    <td><p style="text-align: right">
-2020-12-16</p>
+2021-08-04</p>
 
    </td>
   </tr>
@@ -1040,7 +1040,7 @@ resource.
 <br>
 Min: 1
 <br>
-Max: 1
+Max: >=1
    </td>
    <td>Specifies the parameters used to execute each container instance corresponding to this Revision.
    </td>

--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1040,7 +1040,7 @@ resource.
 <br>
 Min: 1
 <br>
-Max: MAY be larger than 1
+Additionally, implementations MAY enforce an upper bound (≥ 1).
    </td>
    <td>Specifies the parameters used to execute each container instance corresponding to this Revision.
    </td>

--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1040,7 +1040,7 @@ resource.
 <br>
 Min: 1
 <br>
-Max: >=1
+Max: MAY be larger than 1
    </td>
    <td>Specifies the parameters used to execute each container instance corresponding to this Revision.
    </td>


### PR DESCRIPTION
For https://github.com/knative/serving/issues/11735. Allows the max containers number to be larger than 1.

This is for multiple containers, which Knative serving already supports. 