### PR TITLE
Adding note on immutable broker.spec.config

### DIFF
--- a/specs/eventing/control-plane.md
+++ b/specs/eventing/control-plane.md
@@ -449,7 +449,7 @@ resource. The `apiVersion` is `eventing.knative.dev/v1` and the `kind` is
   </tr>
   <tr>
     <td><code>config</code></td>
-    <td><a href="#kreference">KReference</a><br/>(OPTIONAL)</td>
+    <td><a href="#kreference">KReference</a><br/>(OPTIONAL, IMMUTABLE)</td>
     <td>A reference to an object which describes the configuration options for the Broker (for example, a ConfigMap).</td>
   </tr>
   <tr>


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

- :broom: Update API type to be `IMMUTABLE`, to match spec:

> ...
and the spec.config field MUST be immutable; the Broker MUST be deleted and re-created to change the implementation class or spec.config. This pattern is chosen to make it clear that changing the implementation class or spec.config is not an atomic operation and that any implementation would be likely to result in event loss during the transition.


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
