### PR TITLE
Change the schema requirement for `workingdir` to RECOMMENDED

### DIFF
--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1570,7 +1570,7 @@ Max: 1
    </td>
    <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">core/v1.Container</a>.
    </td>
-   <td>REQUIRED
+   <td>RECOMMENDED
    </td>
   </tr>
 </table>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Change the schema requirement for `container.workingDir` field to RECOMMENDED. We propose this change based on:
1. Setting working directory via serving API is not a core feature.
2. Alternatively, users can configure their desired working directory when building the container image.