### PR TITLE
drop logURL requirement

### DIFF
--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1150,7 +1150,7 @@ constitutes a request.
    </td>
    <td>A URL which may be used to retrieve logs specific to this Revision. The destination MAY require authentication and/or use a format (such as a web UI) which requires additional configuration. There is no further standardization of this URL or the targeted endpoint.
    </td>
-   <td>REQUIRED
+   <td>RECOMMENDED
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
`Revision.Status.logURL` is described as 

> A URL which may be used to retrieve logs specific to this Revision. The destination MAY require authentication and/or use a format (such as a web UI) which requires additional configuration. There is no further standardization of this URL or the targeted endpoint.

This property was originally added when we had our monitoring dashboards and the URL would point to Grafana. I believe it's in the spec because the property was there before hand.

Currently this field is `REQUIRED` but I'm unaware of any implementations that set this to a valid URL. I believe this field's requirement level should be `RECOMMENDED`

