### PR TITLE
drop deprecated Revision.Status.imageDigest 

### DIFF
--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1163,16 +1163,6 @@ constitutes a request.
    <td>RECOMMENDED
    </td>
   </tr>
-  <tr>
-   <td><code>imageDigest</code>
-   </td>
-   <td>string
-   </td>
-   <td>The resolved image digest for the requested Container. This MAY be omitted by the implementation.
-   </td>
-   <td>RECOMMENDED
-   </td>
-  </tr>
 </table>
 
 # Detailed Resource Types - v1


### PR DESCRIPTION
The field is accessible via the `Revision.Status.containerStatuses[*].imageDigest `