### PR TITLE
Include additional Container[*].SecurityContext properties

### DIFF
--- a/specs/eventing/control-plane.md
+++ b/specs/eventing/control-plane.md
@@ -130,7 +130,7 @@ Broker MUST provide a `status.address.url` which accepts all valid CloudEvents
 and MUST attempt to forward the received events for filtering to each associated
 Trigger whose `Ready` condition is `true`. As described in the
 [Trigger Lifecycle](#trigger-lifecycle) section, a Broker MAY forward events to
-an associated Trigger destination which which does not currently have a `true`
+an associated Trigger destination which does not currently have a `true`
 `Ready` condition, including events received by the Broker before the Trigger
 was created.
 
@@ -247,7 +247,7 @@ When a Subscription becomes associated with a Channel (either due to creating
 the Subscription or the Channel), the Subscription MUST only set the `Ready`
 condition to `true` after the Channel has been configured to send all future
 events to the Subscription's `spec.subscriber`. The Channel MAY send some events
-to the Subscription before prior to the Subscription's `Ready` condition being
+to the Subscription prior to the Subscription's `Ready` condition being
 set to `true`. When a Subscription is deleted, the Channel MAY send some
 additional events to the Subscription's `spec.subscriber` after the deletion.
 

--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -2225,6 +2225,16 @@ Max: 1
    <td>REQUIRED, if securityContext is supported.
    </td>
   </tr>
+  <tr>
+   <td><code>readOnlyRootFilesystem</code>
+   </td>
+   <td>boolean
+   </td>
+   <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core">core/v1.SecurityContext</a>
+   </td>
+   <td>RECOMMENDED, if securityContext is supported.
+   </td>
+  </tr>
 </table>
 
 ## VolumeMount

--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -2226,6 +2226,16 @@ Max: 1
    </td>
   </tr>
   <tr>
+   <td><code>runAsGroup</code>
+   </td>
+   <td>int
+   </td>
+   <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core">core/v1.SecurityContext</a>
+   </td>
+   <td>REQUIRED, if securityContext is supported.
+   </td>
+  </tr>
+  <tr>
    <td><code>runAsUser</code>
    </td>
    <td>int

--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -2216,16 +2216,6 @@ Max: 1
    </td>
   </tr>
   <tr>
-   <td><code>runAsUser</code>
-   </td>
-   <td>int
-   </td>
-   <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core">core/v1.SecurityContext</a>
-   </td>
-   <td>REQUIRED, if securityContext is supported.
-   </td>
-  </tr>
-  <tr>
    <td><code>readOnlyRootFilesystem</code>
    </td>
    <td>boolean
@@ -2233,6 +2223,16 @@ Max: 1
    <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core">core/v1.SecurityContext</a>
    </td>
    <td>RECOMMENDED, if securityContext is supported.
+   </td>
+  </tr>
+  <tr>
+   <td><code>runAsUser</code>
+   </td>
+   <td>int
+   </td>
+   <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core">core/v1.SecurityContext</a>
+   </td>
+   <td>REQUIRED, if securityContext is supported.
    </td>
   </tr>
 </table>

--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1520,7 +1520,7 @@ Max: 1
 <br>
 (Optional)
    </td>
-   <td>In <code>securityContext</code>, only <code>runAsUser</code> MAY be set.
+   <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">core/v1.Container</a>. 
    </td>
    <td>RECOMMENDED
    </td>


### PR DESCRIPTION
tl;dr

`runAsGroup` - REQUIRED, if securityContext is supported. This compliments `runAsUser`
`readOnlyRootFilesystem` - REQUIRED, if securityContext is supported.


Including `readOnlyRootFilesystem` for the purposes of reserving the keyword.



