### PR TITLE
Adding 408 (Request Timeout) to list of retry-able status codes

### DIFF
--- a/specs/eventing/data-plane.md
+++ b/specs/eventing/data-plane.md
@@ -109,6 +109,7 @@ treated as a retriable error.
 | `3xx`         | (Unspecified)                                     | No\*  | No\*               | Yes\* |
 | `400`         | Unparsable event                                  | No    | No                 | Yes   |
 | `404`         | Endpoint does not exist                           | Yes   | No                 | Yes   |
+| `408`         | Request Timeout                                   | Yes   | No                 | Yes   |
 | `409`         | Conflict / Processing in progress                 | Yes   | No                 | Yes   |
 | `429`         | Too Many Requests / Overloaded                    | Yes   | No                 | Yes   |
 | other `4xx`   | Error                                             | No    | No                 | Yes   |


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

Fixes https://github.com/knative/specs/issues/96

- adding `408` to list of retryable status codes 

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
408 status code should be handled by retry logic 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
