### PR TITLE
Revert Revision.Spec.timeoutSeconds to be max duration and not time to first byte

### DIFF
--- a/specs/serving/knative-api-specification-1.0.md
+++ b/specs/serving/knative-api-specification-1.0.md
@@ -1066,7 +1066,7 @@ Additionally, implementations MAY enforce an upper bound (≥ 1).
 <br>
 (Optional)
    </td>
-   <td>The maximum duration in seconds that the request routing layer will wait for a request delivered to a container to progress (send network traffic). If unspecified, a system default will be provided.
+   <td>The maximum duration in seconds that the instance is allowed to respond to a request. If unspecified, a system default will be provided.
    </td>
    <td>REQUIRED
    </td>


### PR DESCRIPTION
ref: https://github.com/knative/serving/issues/12634

The original serving specification had `Revision.Spec.timeoutSeconds` be the max duration an instance is allowed to handle a request. The OSS implementation deviated from this and it became time to first byte. We're looking to revert to what the spec had originally since it's semantically aligned with other Knative distributions.

Since the spec here was initially seeded from the OSS implementation it needs to be updated to the original language.