### PR TITLE
List out cgroup v2 files for serving contract

### DIFF
--- a/specs/serving/runtime-contract.md
+++ b/specs/serving/runtime-contract.md
@@ -474,9 +474,16 @@ based on observed resource usage. The limits enforced to a container
 [SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/cgroup_test.go)
 be exposed in
 
+cgroup v1:
 - `/sys/fs/cgroup/memory/memory.limit_in_bytes`
+- `/sys/fs/cgroup/cpu/cpu.shares`
 - `/sys/fs/cgroup/cpu/cpu.cfs_period_us`
 - `/sys/fs/cgroup/cpu/cpu.cfs_quota_us`
+
+cgroup v2:
+- `/sys/fs/cgroup/memory.max`
+- `/sys/fs/cgroup/cpu.weight`
+- `/sys/fs/cgroup/cpu.max`
 
 Additionally, operators or the platform MAY restrict or prevent CPU scheduling
 for instances when no requests are active,


### PR DESCRIPTION
This patch lists out cgroup v2 files for serving contract. Since the
current files are only for cgroup v1, this patch updates the spec.

Also add `/sys/fs/cgroup/cpu/cpu.shares` in cgroup v1 list which
was missed.

The conformance test was updated by https://github.com/knative/serving/pull/14297

Fix https://github.com/knative/specs/issues/105

**Release Note**

```release-note
NONE
```
