### PR TITLE
Add clotributor link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ policies and procedures around conformance and certification.
 - [Knative Specs](specs/) contains the core specs for Knative components (Serving and Eventing), along with optional extensions
 - [Policies and Procedures](docs/) provides policies for contributing to the specs, and procedures of testing conformance to the Knative spec, and the Knative certification process
 - [Qualifying Offerings and Self-Testing](/knative-conformance.md) Summarizes the conformance qualification process and eligibility for conformance
+
+## contributing
+
+For a list of help wanted issues across Knative to contribute to, take a look
+at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1).


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/1403

Adds a link to the CLOTRIBUTOR page for Knative to the README