### PR TITLE
Add 401 to the explicitly defined codes

### DIFF
--- a/specs/eventing/data-plane.md
+++ b/specs/eventing/data-plane.md
@@ -108,6 +108,7 @@ treated as a retriable error.
 | other `2xx`   | (Unspecified)                                     | No    | Yes                | No    |
 | `3xx`         | (Unspecified)                                     | No\*  | No\*               | Yes\* |
 | `400`         | Unparsable event                                  | No    | No                 | Yes   |
+| `401`         | Reject received events in case of invalid / missing authentication | No    | No                 | Yes   |
 | `404`         | Endpoint does not exist                           | Yes   | No                 | Yes   |
 | `408`         | Request Timeout                                   | Yes   | No                 | Yes   |
 | `409`         | Conflict / Processing in progress                 | Yes   | No                 | Yes   |

--- a/specs/eventing/data-plane.md
+++ b/specs/eventing/data-plane.md
@@ -108,7 +108,7 @@ treated as a retriable error.
 | other `2xx`   | (Unspecified)                                     | No    | Yes                | No    |
 | `3xx`         | (Unspecified)                                     | No\*  | No\*               | Yes\* |
 | `400`         | Unparsable event                                  | No    | No                 | Yes   |
-| `401`         | Reject received events in case of invalid / missing authentication | No    | No                 | Yes   |
+| `401`         | Invalid / missing authentication         | No    | No                 | Yes   |
 | `404`         | Endpoint does not exist                           | Yes   | No                 | Yes   |
 | `408`         | Request Timeout                                   | Yes   | No                 | Yes   |
 | `409`         | Conflict / Processing in progress                 | Yes   | No                 | Yes   |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->



<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Add 401 to the explicitly defined codes
```
